### PR TITLE
Fix `aws-dynamodb-query`

### DIFF
--- a/bin/aws-dynamodb-query.js
+++ b/bin/aws-dynamodb-query.js
@@ -1,10 +1,8 @@
 #!/bin/env node
 (function() {
     "use strict";
-    var aws = require('../lib/awscli');
-    var DynamoDB = aws.getService("DynamoDB");
-    //aws.setDebug();
     var dynamodb = require('../lib/aws-dynamodb');
+    var Statement = require("../lib/dynamodb-statement");
     var getopt = require('node-getopt').create([
         ['c', 'max-items=ARG',          'The total number of items to return'],
         ['n', 'starting-token=ARG',     'A token to specify where to start paginating'],
@@ -41,121 +39,60 @@
     var sortItemPath = getopt.options['sort-item'];
     var sortDesc = getopt.options['desc'];
 
-    var scanOpts = {};
-    scanOpts["TableName"] = arg.tableName;
-    scanOpts["Limit"] = maxItems;
+    var statement = new Statement();
+    statement.setTableName(arg.tableName);
+    statement.setLimit(maxItems);
 
-    //
-    // Extra options
-    //
-    var extraOptions = {};
-    var projectionExpression = [];
-    var filterExpression = "";
-    var expressionAttributeNames = {};
-    var expressionAttributeValues = {};
-    var select = "ALL_ATTRIBUTES";
-
-    //
     // projection expression
-    //
     var projexpr = getopt.options["projection-expression"];
     if(projexpr) {
-        try {
-            scanOpts["ProjectionExpression"] =
-                dynamodb.parseProjectionExpression(
-                        projexpr, expressionAttributeNames);
-            select = "ALL_PROJECTED_ATTRIBUTES";
-        } catch (err) {
-            console.error("Error in projection-expression:", err.message);
-            process.exit(1);
-        }
+        statement.setProjectionExpression(projexpr);
     }
 
-    //
     // Query expression
-    //
-    (function() {
-        var keyConditionExpr = null;
-        var argExpr = arg.keyConditionExpression;
-        var optExpr = getopt.options["key-condition-expression"];
-        if(argExpr) {
-           if(optExpr) {
-               console.error("Error:",
-                       "Key condition expression is specified",
-                       "at both command line and option.");
-               process.exit(1);
-           }
-           keyConditionExpr = argExpr;
-        } else if(optExpr) {
-           keyConditionExpr = optExpr;
-        } else {
-           console.error("Error:",
-                   "The key condition expression is required.");
-           process.exit(1);
-        }
-        try {
-            scanOpts["KeyConditionExpression"] =
-                dynamodb.parseConditionExpression(keyConditionExpr,
-                    expressionAttributeNames, expressionAttributeValues);
-        } catch (err) {
-            console.error("Error in key-condition-expression:", err.message);
-            process.exit(1);
-        }
-    }());
+    var keyConditionExpr = null;
+    var argExpr = arg.keyConditionExpression;
+    var optExpr = getopt.options["key-condition-expression"];
+    if(argExpr && optExpr) {
+       console.error("Error:",
+               "Key condition expression is specified",
+               "at both command line and option.");
+       process.exit(1);
+    } else if(!argExpr && !optExpr) {
+       console.error("Error:",
+               "The key condition expression is required.");
+       process.exit(1);
+    } else if(argExpr) {
+       keyConditionExpr = argExpr;
+    } else if(optExpr) {
+       keyConditionExpr = optExpr;
+    }
+    statement.setKeyConditionExpression(keyConditionExpr);
 
-    //
     // Filter expression
-    //
     if(getopt.options["filter-expression"]) {
-        try {
-            scanOpts["FilterExpression"] =
-                dynamodb.parseConditionExpression(
-                    getopt.options["filter-expression"],
-                    expressionAttributeNames,
-                    expressionAttributeValues);
-        } catch (err) {
-            console.error("Error in filter-expression:", err.message);
-            process.exit(1);
-        }
+        statement.setFilterExpression(getopt.options["filter-expression"]);
     }
 
-    //
-    // Expression attribute names
-    //
-    if(Object.keys(expressionAttributeNames).length > 0) {
-        scanOpts["ExpressionAttributeNames"] =
-            expressionAttributeNames;
-    }
-
-    //
-    // Expression attribute values
-    //
-    if(Object.keys(expressionAttributeValues).length > 0) {
-        scanOpts["ExpressionAttributeValues"] =
-            expressionAttributeValues;
-    }
-
-    //
     // Dry-run Option
-    //
     if(getopt.options["dry-run"]) {
+        var parameter = statement.getQueryParameter();
         console.log("// opts for aws.dynamodb.query:");
-        console.log(JSON.stringify(scanOpts, null, "    "));
-        process.exit(0);
+        console.log(JSON.stringify(parameter, null, "    "));
+    } else {
+        statement.queryAll(function(err, data) {
+            if(err) {
+                console.error("Error:", err);
+                process.exit(1);
+            }
+            if(getopt.options['output-json']) {
+                console.log(JSON.stringify(data, null, "    "));
+            } else if(getopt.options['output-json-oneline']) {
+                console.log(JSON.stringify(data));
+            } else {
+                dynamodb.printScanResult(data, sortItemPath, sortDesc);
+            }
+        });
     }
-
-    DynamoDB.query(scanOpts, function(err, data) {
-        if(err) {
-            console.error("Error:", err);
-            process.exit(1);
-        }
-        if(getopt.options['output-json']) {
-            console.log(JSON.stringify(data, null, "    "));
-        } else if(getopt.options['output-json-oneline']) {
-            console.log(JSON.stringify(data));
-        } else {
-            dynamodb.printScanResult(data, sortItemPath, sortDesc);
-        }
-    });
 }());
 

--- a/lib/aws-dynamodb-expr-parsers.js
+++ b/lib/aws-dynamodb-expr-parsers.js
@@ -282,7 +282,7 @@
     //
     // Parse
     //
-    ConditionExpression.prototype.parse = function(expr) {
+    ConditionExpression.prototype.parse = function(expr, vidx) {
         this.tokens = [];
         this.expression = [];
         this.names = {};
@@ -290,7 +290,7 @@
 
         this.tokenize(expr);
 
-        var vidx = 0;
+        vidx = vidx | 0;
         this.tokens.forEach(function(token) {
             switch(token.type) {
             case "bool":
@@ -439,7 +439,8 @@
             expressionAttributeValues)
     {
         var parser = new ConditionExpression();
-        parser.parse(conditionExpression);
+        parser.parse(conditionExpression,
+                Object.keys(expressionAttributeValues).length);
 
         var names = parser.getAttributeNames();
         if(names) {

--- a/lib/dynamodb-statement.js
+++ b/lib/dynamodb-statement.js
@@ -1,0 +1,93 @@
+"use strict";
+var aws = require('../lib/awscli');
+var DynamoDB = aws.getService("DynamoDB");
+var parser = require('../lib/aws-dynamodb-expr-parsers');
+function Statement() {
+    this.projectionExpression = null;
+    this.keyConditionExpression = null;
+    this.filterExpression = null;
+    this.expressionAttributeNames = {};
+    this.expressionAttributeValues = {};
+}
+Statement.prototype.setTableName = function(tableName) {
+    this.tableName = tableName;
+};
+Statement.prototype.setLimit = function(limit) {
+    this.limit = limit;
+};
+Statement.prototype.setProjectionExpression = function(projexpr) {
+    try {
+        this.projectionExpression =
+            parser.parseProjectionExpression(
+                    projexpr, this.expressionAttributeNames);
+    } catch (err) {
+        console.error("Error in projection-expression:", err.message);
+        process.exit(1);
+    }
+};
+Statement.prototype.setKeyConditionExpression = function(keyConditionExpr) {
+    try {
+        this.keyConditionExpression =
+            parser.parseConditionExpression(keyConditionExpr,
+                this.expressionAttributeNames,
+                this.expressionAttributeValues);
+    } catch (err) {
+        console.error("Error in key-condition-expression:", err.message);
+        process.exit(1);
+    }
+};
+Statement.prototype.setFilterExpression = function(filterExpr) {
+    try {
+        this.filterExpression =
+            parser.parseConditionExpression(
+                filterExpr,
+                this.expressionAttributeNames,
+                this.expressionAttributeValues);
+    } catch (err) {
+        console.error("Error in filter-expression:", err.message);
+        process.exit(1);
+    }
+}
+Statement.prototype.getScanParameter = function() {
+    var opt = {};
+    if(this.tableName) {
+        opt.TableName = this.tableName;
+    }
+    if(this.limit) {
+        opt.Limit = this.limit;
+    }
+    if(this.projectionExpression) {
+        opt.ProjectionExpression = this.projectionExpression;
+    }
+    if(this.filterExpression) {
+        opt.FilterExpression = this.filterExpression;
+    }
+
+    // Expression attribute names
+    if(Object.keys(this.expressionAttributeNames).length > 0) {
+        opt.ExpressionAttributeNames = this.expressionAttributeNames;
+    }
+
+    // Expression attribute values
+    if(Object.keys(this.expressionAttributeValues).length > 0) {
+        opt.ExpressionAttributeValues = this.expressionAttributeValues;
+    }
+    return opt;
+};
+Statement.prototype.getQueryParameter = function() {
+    var opt = this.getScanParameter();
+    if(this.keyConditionExpression) {
+        opt.KeyConditionExpression = this.keyConditionExpression;
+    }
+    return opt;
+};
+Statement.prototype.scanAll = function(callback) {
+    var parameter = this.getQueryParameter();
+    DynamoDB.scan(parameter, callback);
+};
+Statement.prototype.queryAll = function(callback) {
+    var parameter = this.getQueryParameter();
+    DynamoDB.query(parameter, callback);
+};
+
+module.exports = Statement;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-node-util",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "lockfileVersion": 1,
   "dependencies": {
     "ansi-escape-sequences": {


### PR DESCRIPTION
When an option of `filter-expression` is specified to `aws-dynamodb-query`, the internal indexes of value's placeholder had conflicted with `key-condition-expression`.