### PR TITLE
Fix aws-dynamodb-scan and refactoring

### DIFF
--- a/lib/aws-dynamodb-expr-parsers.js
+++ b/lib/aws-dynamodb-expr-parsers.js
@@ -207,10 +207,6 @@
         }
     };
 
-    var ProjectionExpressionError = function(message, expr) {
-        this.message = message;
-        this.expr = expr;
-    };
     var ProjectionExpression = function() {};
     ProjectionExpression.prototype = new Expression();
     ProjectionExpression.prototype.parse = function(expr) {
@@ -238,11 +234,11 @@
                 if(token.lex == ',') {
                     this.expression.push(token.lex);
                 } else {
-                    throw new ProjectionExpressionError("Invalid delimitor.", expr);
+                    throw new Error("Invalid delimitor. " + expr);
                 }
                 break;
             default:
-                throw new ProjectionExpressionError("R-Value cannot be included.", expr);
+                throw new Error("R-Value cannot be included. " + expr);
                 break;
             }
         }, this);
@@ -350,10 +346,6 @@
     //          "value" : {"M" : {"version": {"S": "0.6.6"}}}
     //      }
     //
-    var ItemListExpressionError = function(message, expr) {
-        this.message = message;
-        this.expr = expr;
-    };
     var ItemListExpression = function() {};
     ItemListExpression.prototype = new Expression();
     ItemListExpression.prototype.parse = function(itemList) {
@@ -375,16 +367,16 @@
         attributeItems.forEach(function(attributeItem) {
             var expr = attributeItem.map(function(token) { return token.lex; }).join(" ");
             if(attributeItem.length != 3) {
-                throw new ItemListExpressionError("Invalid format.", expr);
+                throw new Error("Invalid format. " + expr);
             } else if(attributeItem[0].type != "ident") {
-                throw new ItemListExpressionError("Lvalue must be a item name or map path.", expr);
+                throw new Error("Lvalue must be a item name or map path. " + expr);
             } else if(attributeItem[1].type != "comp" || attributeItem[1].lex != "=") {
-                throw new ItemListExpressionError("The expression must be an assignment.", expr);
+                throw new Error("The expression must be an assignment. " + expr);
             } else if(attributeItem[2].type != "bool" &&
                     attributeItem[2].type != "str" &&
                     attributeItem[2].type != "num")
             {
-                throw new ItemListExpressionError("Rvalue must be a value.", expr);
+                throw new Error("Rvalue must be a value. " + expr);
             }
             var LTok = attributeItem[0];
             var RTok = attributeItem[2];

--- a/lib/aws-dynamodb.js
+++ b/lib/aws-dynamodb.js
@@ -1,8 +1,10 @@
 (function() {
     var fs = require('fs');
     var awscli = require("../lib/awscli");
-    var listit = require('list-it');
+    //awscli.setDebug();
+    var DynamoDB = awscli.getService("DynamoDB");
     awscli.dynamodb = awscli.dynamodb || {};
+
     awscli.dynamodb.putCreateTableJson = function(filename) {
         fs.readFile(filename, function(err, data) {
             if(err) {
@@ -19,6 +21,7 @@
             });
         });
     };
+
     awscli.dynamodb.convertJsonTableDescToCreate = function(desc, callback) {
         var create = desc.Table;
         if(create.GlobalSecondaryIndexes) {
@@ -40,168 +43,28 @@
         delete create.LatestStreamArn;
         callback(null, create);
     };
-    awscli.dynamodb.map2model = function(map) {
-        var dataModel = {};
-        Object.keys(map).forEach(function(key) {
-            Object.keys(map[key]).forEach(function(type) {
-                var value = map[key][type];
-                switch(type) {
-                case "S":
-                    dataModel[key] = value;
-                    break;
-                case "N":
-                    dataModel[key] = parseInt(value);
-                    break;
-                case "BOOL":
-                    dataModel[key] = value;
-                    break;
-                case "M":
-                    dataModel[key] = awscli.dynamodb.map2model(value);
-                    break;
-                }
-            });
-        });
-        return dataModel;
-    };
-    awscli.dynamodb.refAttrByPath = function(obj, path) {
-        var dataitem = obj;
-        var paths = path.split('.');
-        for(var i = 0; i < paths.length; i++) {
-            var pathElement = paths[i];
-            if(typeof(dataitem) != "object"
-                    || !(pathElement in dataitem))
-            {
-                return null;
-            }
-            dataitem = dataitem[pathElement];
-            var types = Object.keys(dataitem);
-            if(types.length > 0) {
-                var type = types[0];
-                dataitem = dataitem[type];
-                switch(type) {
-                case 'N':
-                    if(dataitem.match(/\./)) {
-                        dataitem = parseFloat(dataitem);
-                    } else {
-                        dataitem = parseInt(dataitem);
-                    }
-                    break;
-                case "BOOL":
-                    dataitem = (dataitem == true);
-                    break;
-                }
-            }
-        }
-        return dataitem;
+
+    /**
+     * Scan dynamodb table
+     * @param {type:DynamodbStatement} statement DynamodbStatement
+     * @param {type:Function} callback callback to receive result set.
+     * @returns {undefined}
+     */
+    awscli.dynamodb.runScanStatemnt = function(statement, callback) {
+        var param = statement.getScanParameter();
+        DynamoDB.scan(param, callback);
     };
 
-    //
-    // Print scan result to console
-    //
-    awscli.dynamodb.printScanResult = function(data, sortItemPath, sortDesc) {
-        var colNames = awscli.dynamodb.getAllScannedAttributeNames(data.Items);
-        var rows = awscli.dynamodb.convertItemsTo2dArray(data, colNames);
-        rows = awscli.dynamodb.sortRowsByColumnPath(
-            rows, colNames, sortItemPath, sortDesc);
-
-        if("Count" in data) {
-            console.log("Count:", data.ScannedCount);
-        }
-
-        // format table
-        var buf = listit.buffer({ "autoAlign": true });
-        var rownum = 0;
-        buf.d("ROWNUM");
-        buf.d(colNames);
-        rows.forEach(function(row) {
-            buf.d(++rownum);
-            buf.d(row);
-        });
-        console.log(buf.toString());
-        if("NextToken" in data) {
-            console.log("NextToken:", data.NextToken);
-        }
-        if("ScannedCount" in data) {
-            console.log("ScannedCount:", data.ScannedCount);
-        }
-    };
-    awscli.dynamodb.getAllScannedAttributeNames = function(items) {
-        var colNames = [];
-        var traverseKeys = function(item, namePath) {
-            namePath = namePath || [];
-            Object.keys(item).forEach(function(key) {
-                namePath.push(key);
-                var attrName = namePath.join('.');
-                var type = null;
-                var types = Object.keys(item[key]);
-                if(types.length > 0) {
-                    type = types[0];
-                }
-                if(type == 'M') {
-                    traverseKeys(item[key]['M'], namePath);
-                } else {
-                    if(colNames.indexOf(attrName) < 0) {
-                        colNames.push(attrName);
-                    }
-                }
-                namePath.pop();
-            });
-        };
-
-        // Traverse column names
-        items.forEach(function(item) {
-            traverseKeys(item);
-        });
-
-        return colNames;
+    /**
+     * Query dynamodb table
+     * @param {type:DynamodbStatement} statement DynamodbStatement
+     * @param {type:Function} callback callback to receive result set.
+     * @returns {undefined}
+     */
+    awscli.dynamodb.runQueryStatemnt = function(statement, callback) {
+        var param = statement.getQueryParameter();
+        DynamoDB.query(param, callback);
     };
 
-    //
-    // Convert scan/query result to 2-D array
-    //
-    awscli.dynamodb.convertItemsTo2dArray = function(data, colNames) {
-        var rows = [];
-        data.Items.forEach(function(item) {
-            var cols = [];
-            colNames.forEach(function(pathItem) {
-                var value = awscli.dynamodb.refAttrByPath(item, pathItem);
-                if(value == null) {
-                    value = "";
-                }
-                cols.push(value);
-            });
-            rows.push(cols);
-        });
-        return rows;
-    };
-
-    awscli.dynamodb.sortRowsByColumnPath = function(
-            rows, colNames, sortItemPath, sortDesc)
-    {
-        // Sorting
-        if(sortItemPath) {
-            var col = colNames.indexOf(sortItemPath);
-            if(col >= 0) {
-                for(var i0 = 0; i0 < rows.length; i0++) {
-                    for(var i1 = i0 + 1; i1 < rows.length; i1++) {
-                        if(rows[i0][col] > rows[i1][col]) {
-                            var tmp = rows[i0];
-                            rows[i0] = rows[i1];
-                            rows[i1] = tmp;
-                        }
-                    }
-                }
-            }
-            if(sortDesc) {
-                rows = rows.reverse();
-            }
-        }
-        return rows;
-    };
-
-    var parsers = require("../lib/aws-dynamodb-expr-parsers");
-    awscli.dynamodb.parseProjectionExpression = parsers.parseProjectionExpression;
-    awscli.dynamodb.parseConditionExpression = parsers.parseConditionExpression;
-    awscli.dynamodb.parseItemListToMap = parsers.parseItemListToMap;
     module.exports = awscli.dynamodb;
 }());

--- a/lib/dynamodb-data-models.js
+++ b/lib/dynamodb-data-models.js
@@ -1,0 +1,94 @@
+"use strict";
+var DynamoDbDataType = require("./dynamodb-data-type");
+function DynamoDbDataModels() {}
+DynamoDbDataModels.obj2map = function(value) {
+    if(value == "null") {
+        throw new Error("Cannot convert null");
+    }
+    var type = DynamoDbDataType.detect(value);
+    var typeid = DynamoDbDataType.type2id[type];
+    var map = {};
+    switch(type) {
+        case "Buffer":
+            if(typeof(value) == "string") {
+                map[typeid] = Buffer.from(value, "base64");
+            } else {
+                map[typeid] = value;
+            }
+        case "boolean":
+            map[typeid] = (value ? "true" : "false");
+            break;
+        case "object":
+            {
+                var obj = {};
+                Object.keys(value).forEach(function(key) {
+                    obj[key] = DynamoDbDataModels.obj2map(value[key]);
+                });
+                map[typeid] = obj;
+            }
+            break;
+        case "List":
+            {
+                var obj = [];
+                value.forEach(function(element) {
+                    obj.push(DynamoDbDataModels.obj2map(element));
+                });
+                map[typeid] = obj;
+            }
+            break;
+        case "BufferSequence":
+        case "StringSequence":
+            {
+                var obj = [];
+                value.forEach(function(element) {
+                    obj.push(element);
+                });
+                map[typeid] = obj;
+            }
+            break;
+        case "NumberSequence":
+            {
+                var obj = [];
+                value.forEach(function(element) {
+                    obj.push("" + element);
+                });
+                map[typeid] = obj;
+            }
+            break;
+        case "number":
+            map[typeid] = ("" + value);
+            break;
+        case "undefined":
+            throw new Error("Cannot convert undefind");
+            break;
+        default:
+            map[typeid] = value;
+            break;
+    }
+    return map;
+};
+DynamoDbDataModels.map2obj = function(map) {
+    var obj = {};
+    Object.keys(map).forEach(function(key) {
+        Object.keys(map[key]).forEach(function(type) {
+            var value = map[key][type];
+            switch(type) {
+            case "S":
+                obj[key] = value;
+                break;
+            case "N":
+                obj[key] = parseInt(value);
+                break;
+            case "BOOL":
+                obj[key] = (value=="true");
+                break;
+            case "M":
+                obj[key] = DynamoDbDataModels.map2obj(value);
+                break;
+            }
+        });
+    });
+    return obj;
+};
+
+module.exports = DynamoDbDataModels;

--- a/lib/dynamodb-data-type.js
+++ b/lib/dynamodb-data-type.js
@@ -1,0 +1,125 @@
+"use strict";
+
+//https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#putItem-property
+
+function DynamoDbDataType() {
+    this._is = {
+        BufferSequence: true,
+        NumberSequence: true,
+        StringSequence: true,
+        List: true
+    };
+}
+DynamoDbDataType.primaryTypeOf = function(value) {
+    if(value === null) {
+        return "null";
+    }
+    if(Buffer.isBuffer(value)) {
+        return "Buffer";
+    }
+    if(Array.isArray(value)) {
+        return "Array";
+    }
+    return typeof(value);
+};
+DynamoDbDataType.type2id = {
+    "Buffer": "B",
+    "BufferSequence": "BS",
+    "boolean": "BOOL",
+    "List": "L",
+    "object": "M",
+    "number": "N",
+    "NumberSequence": "NS",
+    "string": "S",
+    "StringSequence": "SS",
+};
+DynamoDbDataType.prototype.countPossibleType = function(element) {
+    var count = 0;
+    Object.keys(this._is).forEach(function(key) {
+        if(this._is[key]) {
+            count++;
+        }
+    }.bind(this));
+    return count;
+};
+DynamoDbDataType.prototype.getPossibleType = function(element) {
+    var type = null;
+    var count = 0;
+    Object.keys(this._is).forEach(function(key) {
+        if(this._is[key]) {
+            type = key;
+            count++;
+        }
+    }.bind(this));
+    if(count > 1) {
+        type = false;
+    }
+    return type;
+};
+DynamoDbDataType.prototype.getPredictedType = function(element) {
+    var count = this.countPossibleType();
+    if(count > 1 && this._is.List) {
+        this._is.List = false;
+        count--;
+    }
+    var type = null;
+    switch(count) {
+        case 0:
+            type = null;
+            break;
+        case 1:
+            type = this.getPossibleType();
+            break;
+        default:
+            type = false;
+            break;
+    }
+    return type;
+};
+DynamoDbDataType.prototype.checkElementType = function(element) {
+    switch(DynamoDbDataType.primaryTypeOf(element)) {
+        case "Buffer":
+            this._is.NumberSequence = false;
+            this._is.StringSequence = false;
+            break;
+        case "number":
+            this._is.BufferSequence = false;
+            this._is.StringSequence = false;
+            break;
+        case "string":
+            this._is.BufferSequence = false;
+            this._is.NumberSequence = false;
+            break;
+        default:
+            this._is.BufferSequence = false;
+            this._is.StringSequence = false;
+            this._is.NumberSequence = false;
+            break;
+    }
+    return this.getPossibleType();
+};
+DynamoDbDataType.detect = function(value) {
+    var type = DynamoDbDataType.primaryTypeOf(value);
+    if(type == "Array") {
+        var detector = new DynamoDbDataType();
+        var arrtype = false;
+        var len = value.length;
+        for(var i = 0; i < len && arrtype === false; i++) {
+            arrtype = detector.checkElementType(value[i]);
+        }
+        if(arrtype == false || arrtype == null) {
+            arrtype = detector.getPredictedType();
+        }
+        type = arrtype;
+    }
+    return type;
+};
+DynamoDbDataType.debug = false;
+var logIndex = 0;
+function log() {
+    if( DynamoDbDataType.debug ) {
+        console.log("[" + logIndex + "]:", Array.from(arguments).join(" "));
+        logIndex++;
+    }
+}
+module.exports = DynamoDbDataType;

--- a/lib/dynamodb-result-set.js
+++ b/lib/dynamodb-result-set.js
@@ -1,0 +1,140 @@
+"use strict";
+var listit = require('list-it');
+
+//
+// Print scan result to console
+//
+function printScanResult(data, sortItemPath, sortDesc) {
+    var colNames = getAllScannedAttributeNames(data.Items);
+    var rows = convertItemsTo2dArray(data, colNames);
+    rows = sortRowsByColumnPath(rows, colNames, sortItemPath, sortDesc);
+
+    if("Count" in data) {
+        console.log("Count:", data.ScannedCount);
+    }
+
+    // format table
+    var buf = listit.buffer({ "autoAlign": true });
+    var rownum = 0;
+    buf.d("ROWNUM");
+    buf.d(colNames);
+    rows.forEach(function(row) {
+        buf.d(++rownum);
+        buf.d(row);
+    });
+    console.log(buf.toString());
+    if("NextToken" in data) {
+        console.log("NextToken:", data.NextToken);
+    }
+    if("ScannedCount" in data) {
+        console.log("ScannedCount:", data.ScannedCount);
+    }
+}
+
+function getAllScannedAttributeNames(items) {
+    var colNames = [];
+    var traverseKeys = function(item, namePath) {
+        namePath = namePath || [];
+        Object.keys(item).forEach(function(key) {
+            namePath.push(key);
+            var attrName = namePath.join('.');
+            var type = null;
+            var types = Object.keys(item[key]);
+            if(types.length > 0) {
+                type = types[0];
+            }
+            if(type == 'M') {
+                traverseKeys(item[key]['M'], namePath);
+            } else {
+                if(colNames.indexOf(attrName) < 0) {
+                    colNames.push(attrName);
+                }
+            }
+            namePath.pop();
+        });
+    };
+
+    // Traverse column names
+    items.forEach(function(item) {
+        traverseKeys(item);
+    });
+
+    return colNames;
+}
+
+//
+// Convert scan/query result to 2-D array
+//
+function convertItemsTo2dArray(data, colNames) {
+    var rows = [];
+    data.Items.forEach(function(item) {
+        var cols = [];
+        colNames.forEach(function(pathItem) {
+            var value = refAttrByPath(item, pathItem);
+            if(value == null) {
+                value = "";
+            }
+            cols.push(value);
+        });
+        rows.push(cols);
+    });
+    return rows;
+}
+
+function refAttrByPath(obj, path) {
+    var dataitem = obj;
+    var paths = path.split('.');
+    for(var i = 0; i < paths.length; i++) {
+        var pathElement = paths[i];
+        if(typeof(dataitem) != "object"
+                || !(pathElement in dataitem))
+        {
+            return null;
+        }
+        dataitem = dataitem[pathElement];
+        var types = Object.keys(dataitem);
+        if(types.length > 0) {
+            var type = types[0];
+            dataitem = dataitem[type];
+            switch(type) {
+            case 'N':
+                if(dataitem.match(/\./)) {
+                    dataitem = parseFloat(dataitem);
+                } else {
+                    dataitem = parseInt(dataitem);
+                }
+                break;
+            case "BOOL":
+                dataitem = (dataitem == true);
+                break;
+            }
+        }
+    }
+    return dataitem;
+}
+
+function sortRowsByColumnPath(rows, colNames, sortItemPath, sortDesc) {
+    // Sorting
+    if(sortItemPath) {
+        var col = colNames.indexOf(sortItemPath);
+        if(col >= 0) {
+            for(var i0 = 0; i0 < rows.length; i0++) {
+                for(var i1 = i0 + 1; i1 < rows.length; i1++) {
+                    if(rows[i0][col] > rows[i1][col]) {
+                        var tmp = rows[i0];
+                        rows[i0] = rows[i1];
+                        rows[i1] = tmp;
+                    }
+                }
+            }
+        }
+        if(sortDesc) {
+            rows = rows.reverse();
+        }
+    }
+    return rows;
+}
+
+module.exports = {
+    printScanResult: printScanResult
+};

--- a/lib/dynamodb-statement.js
+++ b/lib/dynamodb-statement.js
@@ -1,8 +1,9 @@
 "use strict";
-var aws = require('../lib/awscli');
-var DynamoDB = aws.getService("DynamoDB");
 var parser = require('../lib/aws-dynamodb-expr-parsers');
 function Statement() {
+    this.tableName = null;
+    this.limit = null;
+    this.exclusiveStartKey = null;
     this.projectionExpression = null;
     this.keyConditionExpression = null;
     this.filterExpression = null;
@@ -15,38 +16,26 @@ Statement.prototype.setTableName = function(tableName) {
 Statement.prototype.setLimit = function(limit) {
     this.limit = limit;
 };
+Statement.prototype.setExclusiveStartKey = function(lastEvaluatedKey) {
+    this.exclusiveStartKey = lastEvaluatedKey;
+};
 Statement.prototype.setProjectionExpression = function(projexpr) {
-    try {
-        this.projectionExpression =
-            parser.parseProjectionExpression(
-                    projexpr, this.expressionAttributeNames);
-    } catch (err) {
-        console.error("Error in projection-expression:", err.message);
-        process.exit(1);
-    }
+    this.projectionExpression =
+        parser.parseProjectionExpression(
+                projexpr, this.expressionAttributeNames);
 };
 Statement.prototype.setKeyConditionExpression = function(keyConditionExpr) {
-    try {
-        this.keyConditionExpression =
-            parser.parseConditionExpression(keyConditionExpr,
-                this.expressionAttributeNames,
-                this.expressionAttributeValues);
-    } catch (err) {
-        console.error("Error in key-condition-expression:", err.message);
-        process.exit(1);
-    }
+    this.keyConditionExpression =
+        parser.parseConditionExpression(keyConditionExpr,
+            this.expressionAttributeNames,
+            this.expressionAttributeValues);
 };
 Statement.prototype.setFilterExpression = function(filterExpr) {
-    try {
-        this.filterExpression =
-            parser.parseConditionExpression(
-                filterExpr,
-                this.expressionAttributeNames,
-                this.expressionAttributeValues);
-    } catch (err) {
-        console.error("Error in filter-expression:", err.message);
-        process.exit(1);
-    }
+    this.filterExpression =
+        parser.parseConditionExpression(
+            filterExpr,
+            this.expressionAttributeNames,
+            this.expressionAttributeValues);
 }
 Statement.prototype.getScanParameter = function() {
     var opt = {};
@@ -55,6 +44,9 @@ Statement.prototype.getScanParameter = function() {
     }
     if(this.limit) {
         opt.Limit = this.limit;
+    }
+    if(this.exclusiveStartKey) {
+        opt.ExclusiveStartKey = this.exclusiveStartKey;
     }
     if(this.projectionExpression) {
         opt.ProjectionExpression = this.projectionExpression;
@@ -80,14 +72,6 @@ Statement.prototype.getQueryParameter = function() {
         opt.KeyConditionExpression = this.keyConditionExpression;
     }
     return opt;
-};
-Statement.prototype.scanAll = function(callback) {
-    var parameter = this.getQueryParameter();
-    DynamoDB.scan(parameter, callback);
-};
-Statement.prototype.queryAll = function(callback) {
-    var parameter = this.getQueryParameter();
-    DynamoDB.query(parameter, callback);
 };
 
 module.exports = Statement;

--- a/test/test-dynamodb-data-models.js
+++ b/test/test-dynamodb-data-models.js
@@ -1,0 +1,63 @@
+"use strict";
+var assert = require("chai").assert;
+var DynamoDbDataModels = require("../lib/dynamodb-data-models");
+describe("DynamoDbDataModels", function() {
+    describe("obj2map", function() {
+        it("should return String obj", function() {
+            assert.deepEqual({"S":"ABC"}, DynamoDbDataModels.obj2map("ABC"));
+        });
+        it("should return Number obj", function() {
+            assert.deepEqual({ "N": "1.23" }, DynamoDbDataModels.obj2map(1.23));
+        });
+        it("should return BOOL obj", function() {
+            assert.deepEqual({ "BOOL": "true" }, DynamoDbDataModels.obj2map(true));
+            assert.deepEqual({ "BOOL": "false" }, DynamoDbDataModels.obj2map(false));
+        });
+        it("should return Map obj", function() {
+            assert.deepEqual({
+                "M" : {
+                    "A": {"S": "ABC" },
+                    "B": {"N": "1.23" },
+                    "C": {"BOOL": "true" }
+                }
+            },
+            DynamoDbDataModels.obj2map({ A: "ABC", B: 1.23, C: true }));
+        });
+        it("should return List obj", function() {
+            assert.deepEqual({
+                "L" : [
+                    {"S": "ABC" },
+                    {"N": "1.23" },
+                    {"BOOL": "true" }
+                ]
+            },
+            DynamoDbDataModels.obj2map([ "ABC", 1.23, true ]));
+        });
+        it("should return StringSequence obj", function() {
+            assert.deepEqual({
+                "SS" : [ "ABC", "1.23", "true" ]
+            },
+            DynamoDbDataModels.obj2map([ "ABC", "1.23", "true" ]));
+        });
+        it("should return StringSequence obj", function() {
+            assert.deepEqual({
+                "NS" : [ "3", "2", "1", "0.5" ]
+            },
+            DynamoDbDataModels.obj2map([ 3, 2, 1, 0.5 ]));
+        });
+        it("should return BufferSequence obj", function() {
+            assert.deepEqual({
+                "BS" : [
+                    Buffer.from([0,1,2]),
+                    Buffer.from([3,4,5]),
+                    Buffer.from([6,7,8])
+                ]
+            },
+            DynamoDbDataModels.obj2map([
+                    Buffer.from([0,1,2]),
+                    Buffer.from([3,4,5]),
+                    Buffer.from([6,7,8])
+            ]));
+        });
+    });
+});

--- a/test/test-dynamodb-data-type.js
+++ b/test/test-dynamodb-data-type.js
@@ -1,0 +1,430 @@
+"use strict";
+var chai = require("chai");
+var assert = chai.assert;
+var DynamoDbDataType = require("../lib/dynamodb-data-type");
+describe("DynamoDbDataType", function() {
+    describe("class method primaryTypeOf", function() {
+        it("should detect null", function() {
+            var value = null;
+            assert.equal("null", DynamoDbDataType.primaryTypeOf(value));
+        });
+        it("should detect Buffer", function() {
+            var value = Buffer.from("abc", "base64");
+            assert.equal("Buffer", DynamoDbDataType.primaryTypeOf(value));
+        });
+        it("should detect Array", function() {
+            var value = [1,2,3];
+            assert.equal("Array", DynamoDbDataType.primaryTypeOf(value));
+        });
+        it("should detect blank string", function() {
+            var value = "";
+            assert.equal("string", DynamoDbDataType.primaryTypeOf(value));
+        });
+        it("should detect string", function() {
+            var value = "string";
+            assert.equal("string", DynamoDbDataType.primaryTypeOf(value));
+        });
+        it("should detect string", function() {
+            var value = "1.23";
+            assert.equal("string", DynamoDbDataType.primaryTypeOf(value));
+        });
+        it("should detect number for 1.23", function() {
+            var value = 1.23;
+            assert.equal("number", DynamoDbDataType.primaryTypeOf(value));
+        });
+        it("should detect number for 0", function() {
+            var value = 0;
+            assert.equal("number", DynamoDbDataType.primaryTypeOf(value));
+        });
+        it("should detect boolean for true", function() {
+            var value = true;
+            assert.equal("boolean", DynamoDbDataType.primaryTypeOf(value));
+        });
+        it("should detect boolean for false", function() {
+            var value = false;
+            assert.equal("boolean", DynamoDbDataType.primaryTypeOf(value));
+        });
+        it("should detect undefined", function() {
+            var value = undefined;
+            assert.equal("undefined", DynamoDbDataType.primaryTypeOf(value));
+        });
+    });
+    describe("countPossibleType", function() {
+        it("should returns 4 possibilities after construction", function() {
+            var detector = new DynamoDbDataType();
+            assert.equal(4, detector.countPossibleType());
+        });
+        it("should returns number of possibilities", function() {
+            var detector = new DynamoDbDataType();
+
+            //0
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+            assert.equal(0, detector.countPossibleType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+
+            //1
+            assert.equal(1, detector.countPossibleType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+            assert.equal(1, detector.countPossibleType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal(1, detector.countPossibleType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = false;
+            detector._is.List = true;
+            assert.equal(1, detector.countPossibleType());
+
+            //2
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+            assert.equal(2, detector.countPossibleType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal(2, detector.countPossibleType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = false;
+            detector._is.List = true;
+            assert.equal(2, detector.countPossibleType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal(2, detector.countPossibleType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = false;
+            detector._is.List = true;
+            assert.equal(2, detector.countPossibleType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = true;
+            detector._is.List = true;
+            assert.equal(2, detector.countPossibleType());
+
+            //3
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal(3, detector.countPossibleType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = false;
+            detector._is.List = true;
+            assert.equal(3, detector.countPossibleType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = true;
+            detector._is.List = true;
+            assert.equal(3, detector.countPossibleType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = true;
+            assert.equal(3, detector.countPossibleType());
+
+            //4
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = true;
+            assert.equal(4, detector.countPossibleType());
+        });
+    });
+    describe("getPossibleType", function() {
+        it("should returns false after construction", function() {
+            var detector = new DynamoDbDataType();
+            assert.equal(false, detector.getPossibleType());
+        });
+        it("should returns null", function() {
+            var detector = new DynamoDbDataType();
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+            assert.equal(null, detector.getPossibleType());
+        });
+        it("should returns BufferSequence", function() {
+            var detector = new DynamoDbDataType();
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+            assert.equal("BufferSequence", detector.getPossibleType());
+        });
+        it("should returns NumberSequence", function() {
+            var detector = new DynamoDbDataType();
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+            assert.equal("NumberSequence", detector.getPossibleType());
+        });
+        it("should returns StringSequence", function() {
+            var detector = new DynamoDbDataType();
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal("StringSequence", detector.getPossibleType());
+        });
+        it("should returns List", function() {
+            var detector = new DynamoDbDataType();
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = false;
+            detector._is.List = true;
+            assert.equal("List", detector.getPossibleType());
+        });
+        it("should returns false when there are 2 or more possibilities", function() {
+            var detector = new DynamoDbDataType();
+
+            //2
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+            assert.equal(false, detector.getPossibleType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal(false, detector.getPossibleType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = false;
+            detector._is.List = true;
+            assert.equal(false, detector.getPossibleType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal(false, detector.getPossibleType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = false;
+            detector._is.List = true;
+            assert.equal(false, detector.getPossibleType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = true;
+            detector._is.List = true;
+            assert.equal(false, detector.getPossibleType());
+
+            //3
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal(false, detector.getPossibleType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = false;
+            detector._is.List = true;
+            assert.equal(false, detector.getPossibleType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = true;
+            detector._is.List = true;
+            assert.equal(false, detector.getPossibleType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = true;
+            assert.equal(false, detector.getPossibleType());
+
+            //4
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = true;
+            assert.equal(false, detector.getPossibleType());
+        });
+    });
+    describe("getPredictedType", function() {
+        it("should returns false after construction", function() {
+            var detector = new DynamoDbDataType();
+            assert.equal(false, detector.getPredictedType());
+        });
+        it("should returns null", function() {
+            var detector = new DynamoDbDataType();
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+            assert.equal(null, detector.getPredictedType());
+        });
+        it("should returns BufferSequence", function() {
+            var detector = new DynamoDbDataType();
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+            assert.equal("BufferSequence", detector.getPredictedType());
+        });
+        it("should returns NumberSequence", function() {
+            var detector = new DynamoDbDataType();
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+            assert.equal("NumberSequence", detector.getPredictedType());
+        });
+        it("should returns StringSequence", function() {
+            var detector = new DynamoDbDataType();
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal("StringSequence", detector.getPredictedType());
+        });
+        describe("the possibility of List is lower than other candidate", function() {
+            it("should returns BufferSequence", function() {
+                var detector = new DynamoDbDataType();
+                detector._is.BufferSequence = true;
+                detector._is.NumberSequence = false;
+                detector._is.StringSequence = false;
+                detector._is.List = true;
+                assert.equal("BufferSequence", detector.getPredictedType());
+            });
+            it("should returns NumberSequence", function() {
+                var detector = new DynamoDbDataType();
+                detector._is.BufferSequence = false;
+                detector._is.NumberSequence = true;
+                detector._is.StringSequence = false;
+                detector._is.List = true;
+                assert.equal("NumberSequence", detector.getPredictedType());
+            });
+            it("should returns StringSequence", function() {
+                var detector = new DynamoDbDataType();
+                detector._is.BufferSequence = false;
+                detector._is.NumberSequence = false;
+                detector._is.StringSequence = true;
+                detector._is.List = true;
+                assert.equal("StringSequence", detector.getPredictedType());
+            });
+        });
+        it("should returns List", function() {
+            var detector = new DynamoDbDataType();
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = false;
+            detector._is.List = true;
+            assert.equal("List", detector.getPredictedType());
+        });
+        it("should returns false when there are 2 or more possibilities", function() {
+            var detector = new DynamoDbDataType();
+
+            //2
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = false;
+            detector._is.List = false;
+            assert.equal(false, detector.getPredictedType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal(false, detector.getPredictedType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal(false, detector.getPredictedType());
+
+            //3
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = false;
+            assert.equal(false, detector.getPredictedType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = false;
+            detector._is.List = true;
+            assert.equal(false, detector.getPredictedType());
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = false;
+            detector._is.StringSequence = true;
+            detector._is.List = true;
+            assert.equal(false, detector.getPredictedType());
+            detector._is.BufferSequence = false;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = true;
+            assert.equal(false, detector.getPredictedType());
+
+            //4
+            detector._is.BufferSequence = true;
+            detector._is.NumberSequence = true;
+            detector._is.StringSequence = true;
+            detector._is.List = true;
+            assert.equal(false, detector.getPredictedType());
+        });
+    });
+    describe("class method detect", function() {
+        it("should returns null for null", function() {
+            assert.equal("null", DynamoDbDataType.detect(null));
+        });
+        it("should returns string", function() {
+            assert.equal("string", DynamoDbDataType.detect(""));
+        });
+        it("should returns number", function() {
+            assert.equal("number", DynamoDbDataType.detect(1.23));
+        });
+        it("should returns boolean", function() {
+            assert.equal("boolean", DynamoDbDataType.detect(true));
+            assert.equal("boolean", DynamoDbDataType.detect(false));
+        });
+        it("should returns object", function() {
+            assert.equal("object", DynamoDbDataType.detect({}));
+        });
+        it("should returns undefined", function() {
+            assert.equal("undefined", DynamoDbDataType.detect(undefined));
+        });
+        it("should returns Buffer", function() {
+            assert.equal("Buffer", DynamoDbDataType.detect(
+                    new Buffer.from("abc", "base64")));
+        });
+        it("should returns BufferSequence", function() {
+            assert.equal("BufferSequence", DynamoDbDataType.detect([
+                new Buffer.from("abc", "base64"),
+                new Buffer.from("abc", "base64"),
+                new Buffer.from("abc", "base64")]));
+        });
+        it("should returns NumberSequence", function() {
+            assert.equal("NumberSequence", DynamoDbDataType.detect([ 1 ]));
+            assert.equal("NumberSequence", DynamoDbDataType.detect([ 1,2,3 ]));
+        });
+        it("should returns StringSequence", function() {
+            assert.equal("StringSequence", DynamoDbDataType.detect([ "1" ]));
+            assert.equal("StringSequence", DynamoDbDataType.detect([
+                    "1","2","3" ]));
+        });
+        it("should returns List", function() {
+            assert.equal("List", DynamoDbDataType.detect([ "1", 2 ]));
+            assert.equal("List", DynamoDbDataType.detect([ true ]));
+            assert.equal("List", DynamoDbDataType.detect([ false ]));
+            assert.equal("List", DynamoDbDataType.detect([ true, false ]));
+            assert.equal("List", DynamoDbDataType.detect([ {} ]));
+            assert.equal("List", DynamoDbDataType.detect([ [] ]));
+        });
+    });
+});

--- a/test/test-dynamodb-expr-parsers.js
+++ b/test/test-dynamodb-expr-parsers.js
@@ -1,6 +1,6 @@
 "use strict";
 var assert = require("chai").assert;
-var dynamodb = require('../lib/aws-dynamodb');
+var dynamodb = require('../lib/aws-dynamodb-expr-parsers');
 describe("dynamodbExprParsers", function() {
     describe("parseProjectionExpression", function() {
         it("should parse non-keyword names", function() {

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@
 
     // Tests
     describe("aws-dynamodb", function() {
-        var dynamodb = require("../lib/aws-dynamodb.js");
+        var dynamodb = require('../lib/aws-dynamodb-expr-parsers');
         describe("#parseItemListToMap", function() {
             describe("interpret a literal with its type in automatically", function() {
                 describe("integer", function() {


### PR DESCRIPTION
The parameters were not one for the scan but for the query.

* Add AWS specific data converter routine.
* Improve error handling at the expression parser.
* Refactoring scan/query binary.