### PR TITLE
Add feature to query and scan DynamoDB table by SQL-ish statement

### DIFF
--- a/bin/aws-dynamodb-query.js
+++ b/bin/aws-dynamodb-query.js
@@ -1,105 +1,134 @@
 #!/bin/env node
-(function() {
-    "use strict";
-    var dynamodb = require("../lib/aws-dynamodb");
-    dynamodb.connect();
+"use strict";
+var dynamodb = require("../lib/aws-dynamodb");
+dynamodb.connect();
 
-    var Statement = require("../lib/dynamodb-statement");
-    var ResultSet = require("../lib/dynamodb-result-set");
-    var getopt = require('node-getopt').create([
-        ['c', 'max-items=ARG',          'The total number of items to return'],
-        ['n', 'starting-token=ARG',     'A token to specify where to start paginating'],
-        ['s', 'sort-item=ARG',          'JSON path to the sort item'],
-        ['p', 'projection-expression=ARG', 'comma separated attribute names to project'],
-        ['k', 'key-condition-expression=ARG',  'key condition expression of query'],
-        ['f', 'filter-expression=ARG',  'filter expression applied after query'],
-        ['d', 'desc',                   'Sorting direction to descendent'],
-        ['j', 'output-json',            'output a json to read'],
-        ['J', 'output-json-oneline',    'output a json in oneline'],
-        ['t', 'dry-run',                'Print options of the query and exit'],
-        ['h', 'help',                   'display this help']
-        ]).bindHelp().parseSystem();
-    var arg = require('hash-arg').get([
+var Statement = require("../lib/dynamodb-statement");
+var ResultSet = require("../lib/dynamodb-result-set");
+var Getopt = require('node-getopt');
+var optdef = new Getopt([
+    ['c', 'max-items=ARG',          'The total number of items to return'],
+    ['n', 'starting-token=ARG',     'A token to specify where to start paginating'],
+    ['s', 'sort-item=ARG',          'JSON path to the sort item'],
+    ['p', 'projection-expression=ARG', 'comma separated attribute names to project'],
+    ['k', 'key-condition-expression=ARG',  'key condition expression of query'],
+    ['f', 'filter-expression=ARG',  'filter expression applied after query'],
+    ['d', 'desc',                   'Sorting direction to descendent'],
+    ['j', 'output-json',            'output a json to read'],
+    ['J', 'output-json-oneline',    'output a json in oneline'],
+    ['t', 'dry-run',                'Print options of the query and exit'],
+    ['q', 'sql-ish',                'Query by SQL-ish-statement(beta)'],
+    ['h', 'help',                   'display this help']
+    ]);
+
+optdef.setHelp(
+        "Usage:\n" +
+        "1) aws-dynamodb-query [OPTIONS] <tableName> <keyConditionExpression>\n" +
+        "2) aws-dynamodb-query [OPTIONS] -q <SQL-ish-statement>\n" +
+        "\n" +
+        "[[OPTIONS]]\n" +
+        "\n" +
+        "PARAMETERS:\n" +
+        "\n" +
+        "  tableName              The table name defined in DynamoDB.\n" +
+        "  keyConditionExpression KeyConditionExpression for the DynamoDB table.\n" +
+        "  SQL-ish-statement      SQL-ish text that represents a query\n" +
+        "\n" +
+        "  1) In all expression parameter, option value or SQL-ish," +
+        "the field names could be represented as is for " +
+        "its declared name in the table without considering " +
+        "the placeholder of AWS DynamoDB.\n" +
+        "\n" +
+        "  2) Here is an examples showing a syntax for SQL-ish-statement of query.\n" +
+        "\n" +
+        "    [ SELECT <projection-expression> ]\n" +
+        "    FROM <tableName>\n" +
+        "    WHERE <keyConditionExpression>\n" +
+        "    [ FILTER <filter-expression> ]\n" +
+        "    [ LIMIT <max-items> ]\n" +
+        "\n" +
+        "  This says the FROM and WHERE clauses are mandatory and " +
+        "the SELECT, FILTER and LIMIT are optional."
+);
+var getopt = optdef.bindHelp().parseSystem();
+
+var arg = {};
+if(getopt.options["sql-ish"]) {
+    arg = require('hash-arg').get([ "sqlish" ], getopt.argv);
+} else {
+    arg = require('hash-arg').get([
         "tableName",
         "keyConditionExpression"
     ], getopt.argv);
-    if(arg.tableName == null) {
-        console.error("Error: tableName required");
-        process.exit(1);
-    }
-    var maxItems = 20;
-    if(getopt.options['max-items'] != null) {
-        maxItems = parseInt(getopt.options['max-items']);
-        if(isNaN(maxItems) || maxItems <= 0) {
-            console.error("Error: invalid max-items", getopt.options['max-items']);
-            process.exit(1);
+}
+
+try {
+
+    var param;
+    if(getopt.options["sql-ish"]) {
+        param = arg.sqlish;
+    } else {
+        param = {
+            TableName: null,
+            KeyConditionExpression: null
+        };
+
+        // TableName
+        if(!("tableName" in arg)) {
+           console.error("Error:",
+                   "tableName is required.");
+           process.exit(1);
         }
-    }
-    var startingToken = null;
-    if(getopt.options['starting-token'] != null) {
-        startingToken = getopt.options['starting-token'];
-    }
-    var sortItemPath = getopt.options['sort-item'];
-    var sortDesc = getopt.options['desc'];
+        param.TableName = arg.tableName;
 
-    var statement = new Statement();
-    statement.setTableName(arg.tableName);
-    statement.setLimit(maxItems);
-
-    // projection expression
-    var projexpr = getopt.options["projection-expression"];
-    if(projexpr) {
-        try {
-            statement.setProjectionExpression(projexpr);
-        } catch (err) {
-            console.error("Error in projection-expression:", err.message);
-            process.exit(1);
+        // KeyConditionExpression
+        var argExpr = arg.keyConditionExpression;
+        var optExpr = getopt.options["key-condition-expression"];
+        if(argExpr && optExpr) {
+           console.error("Error:",
+                   "Key condition expression is specified",
+                   "at both command line and option.");
+           process.exit(1);
+        } else if(!argExpr && !optExpr) {
+           console.error("Error:",
+                   "The key condition expression is required.");
+           process.exit(1);
+        } else if(argExpr) {
+           param.KeyConditionExpression = argExpr;
+        } else if(optExpr) {
+           param.KeyConditionExpression = optExpr;
         }
-    }
 
-    // Query expression
-    var keyConditionExpr = null;
-    var argExpr = arg.keyConditionExpression;
-    var optExpr = getopt.options["key-condition-expression"];
-    if(argExpr && optExpr) {
-       console.error("Error:",
-               "Key condition expression is specified",
-               "at both command line and option.");
-       process.exit(1);
-    } else if(!argExpr && !optExpr) {
-       console.error("Error:",
-               "The key condition expression is required.");
-       process.exit(1);
-    } else if(argExpr) {
-       keyConditionExpr = argExpr;
-    } else if(optExpr) {
-       keyConditionExpr = optExpr;
-    }
-    try {
-        statement.setKeyConditionExpression(keyConditionExpr);
-    } catch (err) {
-        console.error("Error in key-condition-expression:", err.message);
-        process.exit(1);
-    }
+        // FilterExpression
+        if("filter-expression" in getopt.options) {
+            param.FilterExpression = getopt.options["filter-expression"];
+        }
 
-    // Filter expression
-    if(getopt.options["filter-expression"]) {
-        try {
-            statement.setFilterExpression(getopt.options["filter-expression"]);
-        } catch (err) {
-            console.error("Error in filter-expression:", err.message);
-            process.exit(1);
+        // ProjectionExpression
+        if("projection-expression" in getopt.options) {
+            param.ProjectionExpression = getopt.options["projection-expression"];
+        }
+
+        // Limit
+        if('max-items' in getopt.options) {
+            param.Limit = parseInt(getopt.options['max-items']);
+        }
+
+        var startingToken = null;
+        if('starting-token' in getopt.options) {
+            startingToken = getopt.options['starting-token'];
         }
     }
 
-    // Query
+    var statement = Statement.prepareQuery(param);
 
-    // Dry-run Option
     if(getopt.options["dry-run"]) {
         var queryParam = statement.getQueryParameter();
         console.log("// opts for aws.dynamodb.query:");
         console.log(JSON.stringify(queryParam, null, "    "));
     } else {
+
+        // Query
         dynamodb.runQueryStatemnt(statement, function(err, data) {
             if(err) {
                 console.error("Error:", err);
@@ -110,9 +139,13 @@
             } else if(getopt.options['output-json-oneline']) {
                 console.log(JSON.stringify(data));
             } else {
-                ResultSet.printScanResult(data, sortItemPath, sortDesc);
+                ResultSet.printScanResult(data,
+                        getopt.options['sort-item'],
+                        getopt.options['desc']);
             }
         });
     }
-}());
-
+} catch(err) {
+    console.error("Error: ", err.message);
+    process.exit(1);
+}

--- a/bin/aws-dynamodb-scan.js
+++ b/bin/aws-dynamodb-scan.js
@@ -1,74 +1,111 @@
 #!/bin/env node
-(function() {
-    "use strict";
-    var dynamodb = require("../lib/aws-dynamodb");
-    var Statement = require("../lib/dynamodb-statement");
-    var ResultSet = require("../lib/dynamodb-result-set");
-    var getopt = require('node-getopt').create([
-        ['c', 'max-items=ARG',          'The total number of items to return'],
-        ['n', 'starting-token=ARG',     'A token to specify where to start paginating'],
-        ['s', 'sort-item=ARG',     'JSON path to the sort item'],
-        ['p', 'projection-expression=ARG', 'comma separated attribute names to project'],
-        ['f', 'filter-expression=ARG',  'filter expression'],
-        ['d', 'desc',                   'Sorting direction to descendent'],
-        ['j', 'output-json',            'output a json to read'],
-        ['J', 'output-json-oneline',    'output a json in oneline'],
-        ['t', 'dry-run',                'Print options of the scan and exit'],
-        ['h', 'help',                   'display this help']
-        ]).bindHelp().parseSystem();
-    var arg = require('hash-arg').get([
+"use strict";
+var dynamodb = require("../lib/aws-dynamodb");
+dynamodb.connect();
+
+var Statement = require("../lib/dynamodb-statement");
+var ResultSet = require("../lib/dynamodb-result-set");
+var Getopt = require('node-getopt');
+var optdef = new Getopt([
+    ['c', 'max-items=ARG',          'The total number of items to return'],
+    ['n', 'starting-token=ARG',     'A token to specify where to start paginating'],
+    ['s', 'sort-item=ARG',          'JSON path to the sort item'],
+    ['p', 'projection-expression=ARG', 'comma separated attribute names to project'],
+    ['f', 'filter-expression=ARG',  'filter expression'],
+    ['d', 'desc',                   'Sorting direction to descendent'],
+    ['j', 'output-json',            'output a json to read'],
+    ['J', 'output-json-oneline',    'output a json in oneline'],
+    ['t', 'dry-run',                'Print options of the scan and exit'],
+    ['q', 'sql-ish',                'Query by SQL-ish-statement(beta)'],
+    ['h', 'help',                   'display this help']
+    ]);
+
+optdef.setHelp(
+        "Usage:\n" +
+        "1) aws-dynamodb-scan [OPTIONS] <tableName>\n" +
+        "2) aws-dynamodb-scan [OPTIONS] -q <SQL-ish-statement>\n" +
+        "\n" +
+        "[[OPTIONS]]\n" +
+        "\n" +
+        "PARAMETERS:\n" +
+        "\n" +
+        "  tableName              The table name defined in DynamoDB.\n" +
+        "  SQL-ish-statement      SQL-ish text that represents a scan\n" +
+        "\n" +
+        "  1) In all expression parameter, option value or SQL-ish," +
+        "the field names could be represented as is for " +
+        "its declared name in the table without considering " +
+        "the placeholder of AWS DynamoDB.\n" +
+        "\n" +
+        "  2) Here is an examples showing a syntax for SQL-ish-statement of scan.\n" +
+        "\n" +
+        "    [ SELECT <projection-expression> ]\n" +
+        "    FROM <tableName>\n" +
+        "    [ WHERE <filter-expression> ]\n" +
+        "    [ LIMIT <max-items> ]\n" +
+        "\n" +
+        "  This says the FROM clauses is mandatory and " +
+        "the SELECT, WHERE and LIMIT are optional."
+);
+
+var getopt = optdef.bindHelp().parseSystem();
+
+var arg = {};
+if(getopt.options["sql-ish"]) {
+    arg = require('hash-arg').get([ "sqlish" ], getopt.argv);
+} else {
+    arg = require('hash-arg').get([
         "tableName"
     ], getopt.argv);
-    if(arg.tableName == null) {
-        console.error("Error: tableName required");
-        process.exit(1);
-    }
-    var maxItems = 20;
-    if(getopt.options['max-items'] != null) {
-        maxItems = parseInt(getopt.options['max-items']);
-        if(isNaN(maxItems) || maxItems <= 0) {
-            console.error("Error: invalid max-items", getopt.options['max-items']);
-            process.exit(1);
-        }
-    }
-    var startingToken = null;
-    if(getopt.options['starting-token'] != null) {
-        startingToken = getopt.options['starting-token'];
-    }
-    var sortItemPath = getopt.options['sort-item'];
-    var sortDesc = getopt.options['desc'];
+}
+try {
 
-    var statement = new Statement();
-    var scanOpts = {};
-    statement.setTableName(arg.tableName);
-    statement.setLimit(maxItems);
-
-    // projection expression
-    var projexpr = getopt.options["projection-expression"];
-    if(projexpr) {
-        try {
-            statement.setProjectionExpression(projexpr);
-        } catch (err) {
-            console.error("Error in projection-expression:", err.message);
-            process.exit(1);
-        }
-    }
-
-    // Filter expression
-    if(getopt.options["filter-expression"]) {
-        statement.setFilterExpression(getopt.options["filter-expression"]);
-    }
-
-    //
-    // Scan
-    //
-    if(getopt.options["dry-run"]) {
-        var scanParam = statement.getScanParameter();
-        console.log("// opts for aws.dynamodb.scan:");
-        console.log(JSON.stringify(scanParam, null, "    "));
-        process.exit(0);
+    var param;
+    if(getopt.options["sql-ish"]) {
+        param = arg.sqlish;
     } else {
-        dynamodb.connect();
+        param = {
+            TableName: null
+        };
+
+        // TableName
+        if(!("tableName" in arg)) {
+           console.error("Error:",
+                   "tableName is required.");
+           process.exit(1);
+        }
+        param.TableName = arg.tableName;
+
+        // FilterExpression
+        if("filter-expression" in getopt.options) {
+            param.FilterExpression = getopt.options["filter-expression"];
+        }
+
+        // ProjectionExpression
+        if("projection-expression" in getopt.options) {
+            param.ProjectionExpression = getopt.options["projection-expression"];
+        }
+
+        // Limit
+        if('max-items' in getopt.options) {
+            param.Limit = parseInt(getopt.options['max-items']);
+        }
+
+        var startingToken = null;
+        if('starting-token' in getopt.options) {
+            startingToken = getopt.options['starting-token'];
+        }
+    }
+
+    var statement = Statement.prepareScan(param);
+
+    if(getopt.options["dry-run"]) {
+        var queryParam = statement.getScanParameter();
+        console.log("// opts for aws.dynamodb.scan:");
+        console.log(JSON.stringify(queryParam, null, "    "));
+    } else {
+
+        // Scan
         dynamodb.runScanStatemnt(statement, function(err, data) {
             if(err) {
                 console.error("Error:", err);
@@ -79,9 +116,14 @@
             } else if(getopt.options['output-json-oneline']) {
                 console.log(JSON.stringify(data));
             } else {
-                ResultSet.printScanResult(data, sortItemPath, sortDesc);
+                ResultSet.printScanResult(data,
+                        getopt.options['sort-item'],
+                        getopt.options['desc']);
             }
         });
     }
-}());
-
+} catch(err) {
+    console.error("Error: ", err.message);
+    console.error("Error: ", err.stack);
+    process.exit(1);
+}

--- a/lib/dynamodb-statement.js
+++ b/lib/dynamodb-statement.js
@@ -10,33 +10,139 @@ function Statement() {
     this.expressionAttributeNames = {};
     this.expressionAttributeValues = {};
 }
+
 Statement.prototype.setTableName = function(tableName) {
     this.tableName = tableName;
 };
+
 Statement.prototype.setLimit = function(limit) {
     this.limit = limit;
 };
+
 Statement.prototype.setExclusiveStartKey = function(lastEvaluatedKey) {
     this.exclusiveStartKey = lastEvaluatedKey;
 };
+
 Statement.prototype.setProjectionExpression = function(projexpr) {
     this.projectionExpression =
         parser.parseProjectionExpression(
                 projexpr, this.expressionAttributeNames);
 };
+
 Statement.prototype.setKeyConditionExpression = function(keyConditionExpr) {
     this.keyConditionExpression =
         parser.parseConditionExpression(keyConditionExpr,
             this.expressionAttributeNames,
             this.expressionAttributeValues);
 };
+
 Statement.prototype.setFilterExpression = function(filterExpr) {
     this.filterExpression =
         parser.parseConditionExpression(
             filterExpr,
             this.expressionAttributeNames,
             this.expressionAttributeValues);
-}
+};
+
+Statement.parseScanSQLish = function(sqlish) {
+    var opt = {};
+    sqlish = sqlish.replace(/(\r|)\n/g, ' ');
+    var matches = sqlish.match(/^\s*(SELECT\s+(.*)|)\s*(FROM\s+([^\s]+))\s*(.*)\s*$/i);
+    if(matches && matches.length > 2 && matches[2]) {
+        opt.ProjectionExpression = matches[2].replace(/^\s*/, "").replace(/\s*$/, "");
+    }
+    opt.TableName = matches[4];
+    var whereFilterLimit = matches[5];
+    if(whereFilterLimit.match(/WHERE/i)) {
+        opt.KeyConditionExpression = whereFilterLimit.replace(/\s+WHERE\s.*$/i, "").replace(/^\s*/, "").replace(/\s*$/, "");
+        if(whereFilterLimit.match(/LIMIT/i)) {
+            opt.FilterExpression = whereFilterLimit.replace(/^.*\s*WHERE\s+(.*)\s+LIMIT\s+.*$/i, "$1");
+            opt.Limit = whereFilterLimit.replace(/^.*\s*LIMIT\s+(\d*)\s*$/i, "$1");
+        } else {
+            opt.FilterExpression = whereFilterLimit.replace(/^.*\s*WHERE\s+(.*)\s*$/i, "$1");
+        }
+    } else if(whereFilterLimit.match(/LIMIT/i)) {
+        opt.KeyConditionExpression = whereFilterLimit.replace(/\s+LIMIT\s*.*$/i, "").replace(/^\s*/, "").replace(/\s*$/, "");
+        opt.Limit = whereFilterLimit.replace(/^.*\s*LIMIT\s+(\d*)\s*$/i, "$1");
+    } else {
+        opt.KeyConditionExpression = whereFilterLimit.replace(/\s+$/i, "").replace(/^\s*/, "");
+    }
+    return opt;
+
+};
+
+Statement.prepareScan = function(opt) {
+    var statement = new Statement();
+    if(typeof(opt) === "string") {
+        opt = Statement.parseScanSQLish(opt);
+    }
+    if(!("TableName" in opt)) {
+        throw new Error("TableName required");
+    }
+    statement.setTableName(opt.TableName);
+    if("FilterExpression" in opt) {
+        statement.setFilterExpression(opt.FilterExpression);
+    }
+    if("ProjectionExpression" in opt) {
+        statement.setProjectionExpression(opt.ProjectionExpression);
+    }
+    if("Limit" in opt) {
+        statement.setLimit(opt.Limit);
+    }
+    return statement;
+};
+
+Statement.parseQuerySQLish = function(sqlish) {
+    var opt = {};
+    sqlish = sqlish.replace(/(\r|)\n/g, ' ');
+    var matches = sqlish.match(/^\s*(SELECT\s+(.*)|)\s*(FROM\s+(.*))\s+(WHERE\s+(.*))$/i);
+    if(matches && matches.length > 2 && matches[2]) {
+        opt.ProjectionExpression = matches[2].replace(/^\s*/, "").replace(/\s*$/, "");
+    }
+    opt.TableName = matches[4];
+    var whereFilterLimit = matches[6];
+    if(whereFilterLimit.match(/FILTER/i)) {
+        opt.KeyConditionExpression = whereFilterLimit.replace(/\s+FILTER\s.*$/i, "").replace(/^\s*/, "").replace(/\s*$/, "");
+        if(whereFilterLimit.match(/LIMIT/i)) {
+            opt.FilterExpression = whereFilterLimit.replace(/^.*\s*FILTER\s+(.*)\s+LIMIT\s+.*$/i, "$1");
+            opt.Limit = whereFilterLimit.replace(/^.*\s*LIMIT\s+(\d*)\s*$/i, "$1");
+        } else {
+            opt.FilterExpression = whereFilterLimit.replace(/^.*\s*FILTER\s+(.*)\s*$/i, "$1");
+        }
+    } else if(whereFilterLimit.match(/LIMIT/i)) {
+        opt.KeyConditionExpression = whereFilterLimit.replace(/\s+LIMIT\s*.*$/i, "").replace(/^\s*/, "").replace(/\s*$/, "");
+        opt.Limit = whereFilterLimit.replace(/^.*\s*LIMIT\s+(\d*)\s*$/i, "$1");
+    } else {
+        opt.KeyConditionExpression = whereFilterLimit.replace(/\s+$/i, "").replace(/^\s*/, "");
+    }
+    return opt;
+};
+
+Statement.prepareQuery = function(opt) {
+    var statement = new Statement();
+    if(typeof(opt) === "string") {
+        opt = Statement.parseQuerySQLish(opt);
+    }
+    if(!("TableName" in opt)) {
+        throw new Error("TableName required");
+    }
+    if(!("KeyConditionExpression" in opt)) {
+        throw new Error("KeyConditionExpression required");
+    }
+    statement.setTableName(opt.TableName);
+    statement.setKeyConditionExpression(opt.KeyConditionExpression);
+    if("FilterExpression" in opt) {
+        statement.setFilterExpression(opt.FilterExpression);
+    }
+    if("ProjectionExpression" in opt) {
+        statement.setProjectionExpression(opt.ProjectionExpression);
+    }
+    if("Limit" in opt) {
+        statement.setLimit(opt.Limit);
+    }
+    return statement;
+};
+
 Statement.prototype.getScanParameter = function() {
     var opt = {};
     if(this.tableName) {
@@ -66,6 +172,7 @@ Statement.prototype.getScanParameter = function() {
     }
     return opt;
 };
+
 Statement.prototype.getQueryParameter = function() {
     var opt = this.getScanParameter();
     if(this.keyConditionExpression) {

--- a/test/test-dynamodb-statement.js
+++ b/test/test-dynamodb-statement.js
@@ -1,0 +1,87 @@
+"use strict";
+var assert = require("chai").assert;
+var Statement = require("../lib/dynamodb-statement");
+describe("DynamoDB Statement", function() {
+    describe("parseScanSQLish", function() {
+        it("can parse SQL-ish that all clause is included", function() {
+            var param = Statement.parseScanSQLish(
+                "SELECT A, B, C \r\n" +
+                "FROM TBL \n" +
+                "WHERE F=FilterValue Limit\n" +
+                "10");
+            assert.equal("A, B, C", param.ProjectionExpression);
+            assert.equal("TBL", param.TableName);
+            assert.equal("F=FilterValue", param.FilterExpression);
+            assert.equal("10", param.Limit);
+        });
+        it("can parse SQL-ish that dose not have optional clause", function() {
+            var param = Statement.parseScanSQLish(
+                    " FROM TBL");
+            assert.equal(false, "ProjectionExpression" in param);
+            assert.equal("TBL", param.TableName);
+            assert.equal(false, "FilterExpression" in param);
+            assert.equal(false, "Limit" in param);
+        });
+        it("can parse SQL-ish that has various pattern", function() {
+            var param = Statement.parseScanSQLish(
+                    "  SELECT A,B,C FROM TBL Limit 10   ");
+            assert.equal("A,B,C", param.ProjectionExpression);
+            assert.equal("TBL", param.TableName);
+            assert.equal(false, "FilterExpression" in param);
+            assert.equal("10", param.Limit);
+        });
+        it("can parse SQL-ish that has various pattern", function() {
+            var param = Statement.parseScanSQLish(
+                    "FROM stars WHERE mainStar='SUN' AND orbitOrder BETWEEN 1 AND 9\n" +
+                    "AND mass<1");
+            assert.equal(false, "ProjectionExpression" in param);
+            assert.equal("stars", param.TableName);
+            assert.equal("mainStar='SUN' AND orbitOrder BETWEEN 1 AND 9 AND mass<1",
+                    param.FilterExpression);
+            assert.equal(false, "Limit" in param);
+        });
+    });
+    describe("parseQuerySQLish", function() {
+        it("can parse SQL-ish that all clause is included", function() {
+            var param = Statement.parseQuerySQLish(
+                "SELECT A, B, C \r\n" +
+                "FROM TBL WHERE Key=KeyValue\n" +
+                "FILTER F=FilterValue Limit\n" +
+                "10");
+            assert.equal("A, B, C", param.ProjectionExpression);
+            assert.equal("TBL", param.TableName);
+            assert.equal("Key=KeyValue", param.KeyConditionExpression);
+            assert.equal("F=FilterValue", param.FilterExpression);
+            assert.equal("10", param.Limit);
+        });
+        it("can parse SQL-ish that dose not have optional clause", function() {
+            var param = Statement.parseQuerySQLish(
+                    " FROM TBL WHERE Key=KeyValue ");
+            assert.equal(false, "ProjectionExpression" in param);
+            assert.equal("TBL", param.TableName);
+            assert.equal("Key=KeyValue", param.KeyConditionExpression);
+            assert.equal(false, "FilterExpression" in param);
+            assert.equal(false, "Limit" in param);
+        });
+        it("can parse SQL-ish that has various pattern", function() {
+            var param = Statement.parseQuerySQLish(
+                    "  SELECT A,B,C FROM TBL WHERE Key = KeyValue Limit 10   ");
+            assert.equal("A,B,C", param.ProjectionExpression);
+            assert.equal("TBL", param.TableName);
+            assert.equal("Key = KeyValue", param.KeyConditionExpression);
+            assert.equal(false, "FilterExpression" in param);
+            assert.equal("10", param.Limit);
+        });
+        it("can parse SQL-ish that has various pattern", function() {
+            var param = Statement.parseQuerySQLish(
+                    "FROM stars WHERE mainStar='SUN' AND orbitOrder BETWEEN 1 AND 9\n" +
+                    "FILTER mass<1");
+            assert.equal(false, "ProjectionExpression" in param);
+            assert.equal("stars", param.TableName);
+            assert.equal("mainStar='SUN' AND orbitOrder BETWEEN 1 AND 9",
+                    param.KeyConditionExpression);
+            assert.equal("mass<1", param.FilterExpression);
+            assert.equal(false, "Limit" in param);
+        });
+    });
+});


### PR DESCRIPTION
A simple explanation is shown by specifing an option `--help` for
`aws-dynamodb-query -h` or `aws-dynamodb-scan`.