### PR TITLE
Fix the aws-dynamodb-scan/query binary

### DIFF
--- a/bin/aws-dynamodb-query.js
+++ b/bin/aws-dynamodb-query.js
@@ -114,14 +114,13 @@ try {
         if('max-items' in getopt.options) {
             param.Limit = parseInt(getopt.options['max-items']);
         }
-
-        if('starting-token' in getopt.options) {
-            // This parameter will be set to ExclusiveStartKey parameter of SCAN-API
-            param.LastEvaluatedKey = JSON.parse(getopt.options['starting-token']);
-        }
     }
 
     const statement = new DynamoDBQueryStatement(param);
+    if('starting-token' in getopt.options) {
+        const lastEvaluatedKey = JSON.parse(getopt.options['starting-token']);
+        statement.setExclusiveStartKey(lastEvaluatedKey);
+    }
     awscli.connect();
     statement.dynamodb = awscli.getService("DynamoDB");
     var placeholderValues = {};

--- a/bin/aws-dynamodb-scan.js
+++ b/bin/aws-dynamodb-scan.js
@@ -91,14 +91,13 @@ try {
         if('max-items' in getopt.options) {
             param.Limit = parseInt(getopt.options['max-items']);
         }
-
-        if('starting-token' in getopt.options) {
-            // This parameter will be set to ExclusiveStartKey parameter of SCAN-API
-            param.LastEvaluatedKey = JSON.parse(getopt.options['starting-token']);
-        }
     }
 
     const statement = new DynamoDBScanStatement(param);
+    if('starting-token' in getopt.options) {
+        const lastEvaluatedKey = JSON.parse(getopt.options['starting-token']);
+        statement.setExclusiveStartKey(lastEvaluatedKey);
+    }
     awscli.connect();
     statement.dynamodb = awscli.getService("DynamoDB");
     var placeholderValues = {};

--- a/lib/dynamodb-query-statement.js
+++ b/lib/dynamodb-query-statement.js
@@ -47,7 +47,7 @@ function DynamoDbQueryStatement(opt) {
         this.setLimit(opt.Limit);
     }
     if("LastEvaluatedKey" in opt) {
-        this.exclusiveStartKey = opt.LastEvaluatedKey;
+        this.setExclusiveStartKey(opt.LastEvaluatedKey);
     }
 }
 

--- a/lib/dynamodb-scan-statement.js
+++ b/lib/dynamodb-scan-statement.js
@@ -44,7 +44,7 @@ function DynamoDbScanStatement(opt) {
         this.setLimit(opt.Limit);
     }
     if("LastEvaluatedKey" in opt) {
-        this.exclusiveStartKey = opt.LastEvaluatedKey;
+        this.setExclusiveStartKey(opt.LastEvaluatedKey);
     }
 }
 


### PR DESCRIPTION
Those could not accept the ExclusiveStartKey option, when SQL-ish
statement is specified.